### PR TITLE
Minor `start.sh` script changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 ## How to use:
 - create a new fleet on Balena https://balena.io
 - create a network on ZeroTier https://my.zerotier.com/
+- under `IPv4 Auto-Assign`, choose a IP address range that doesn't conflict with existing networks
+  - if your network is `192.168.*.*`, make sure to choose something different, like `10.144.*.*`. 
 - copy the network ID (e.g. abcd12ef3456gh78)
 - update the application variables on Balena, add:
   - `ZT_NETWORK` = ZeroTier network ID
@@ -18,6 +20,7 @@
   - they can now use the connection as their default route
 
 ## Tested on:
-- Raspberry Pi 3B+ running BalenaOS 2.95.8
+- Raspberry Pi 3B+ running balenaOS 2.95.8
   - ZeroTier version 1.8.7
-
+- Raspberry Pi 4, running balenaOS >=2.88.5
+  - ZeroTier version 1.8.7

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -8,12 +8,18 @@ zerotier-cli join $ZT_NETWORK
 # zerotier-cli set $ZT_NETWORK allowManaged=0
 
 PHY_IFACE="$(ip route | grep default | cut -d' ' -f5)"
-ZT_IFACE="$(zerotier-cli listnetworks | tail -n1 | cut -d' ' -f9)"
+
+# cut -f9 returns IP block (or - if no IP address), -f8 will return the network interface
+ZT_IFACE="$(zerotier-cli listnetworks | tail -n1 | cut -d' ' -f8)"
 
 sysctl -w net.ipv4.ip_forward=1
-iptables -t nat -A POSTROUTING -o $PHY_IFACE -j MASQUERADE
-iptables -A FORWARD -i $ZT_IFACE -o $PHY_IFACE -j ACCEPT
-iptables -A FORWARD -i $PHY_IFACE -o $ZT_IFACE -m state --state RELATED,ESTABLISHED -j ACCEPT
+
+# looping for multiple physical interfaces
+for IFACE in ${PHY_IFACE//\s/ }; do
+  iptables -t nat -A POSTROUTING -o $IFACE -j MASQUERADE
+  iptables -A FORWARD -i $ZT_IFACE -o $IFACE -j ACCEPT
+  iptables -A FORWARD -i $IFACE -o $ZT_IFACE -m state --state RELATED,ESTABLISHED -j ACCEPT
+done
 
 while true; do
   # brctl show box0 | grep ztbpaltgeu > /dev/null 2>&1


### PR DESCRIPTION
Changes:
  - Looping over `PHY_IFACE` in case there are multiple physical interfaces (`eth0` + `wlan0` is the most common)
  - `ZT_IFACE` variable was pulling the IP address, not actual interface name for the configured network (note, this line also doesn't allow for multiple networks if there are more than one)
  - Minor notes in the `README`