### PR TITLE
Added support for multiple concurrent networks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
   - if your network is `192.168.*.*`, make sure to choose something different, like `10.144.*.*`. 
 - copy the network ID (e.g. abcd12ef3456gh78)
 - update the application variables on Balena, add:
-  - `ZT_NETWORK` = ZeroTier network ID
+  - `ZT_NETWORK` = ZeroTier network ID 
+  - join multiple networks by separating the IDs with a comma
 - push this repository to your balena application
 - add a device to your Balena fleet
 - wait until the device has started and is running the application

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,24 +1,52 @@
 #!/bin/bash
 
 printf "### Starting ZeroTier interface"
+printf " "
 
 service zerotier-one start
 sleep 5
-zerotier-cli join $ZT_NETWORK
+
+# fetch ZT_NETWORK specified in balena environment variable, clean whitespaces and commas if any
+ZT_NETWORKS="$(echo $ZT_NETWORK | tr -d '[:space:]' | tr ',' '\n')"
+
 # zerotier-cli set $ZT_NETWORK allowManaged=0
+
+# fetch currently joined networks
+ZT_CURRENT_NETWORKS="$(zerotier-cli listnetworks -j | jq -r '.[] | (.id)')"
+
+# join networks specified in environment variable,
+for ZT_NETWORK in ${ZT_NETWORKS}; do
+  if ! echo "$ZT_CURRENT_NETWORKS" | grep -q "$ZT_NETWORK"; then
+    echo "Joining $ZT_NETWORK";
+    zerotier-cli join $ZT_NETWORK;
+  fi
+done
+
+# leave networks not specified in environment variable
+for ZT_CURRENT_NETWORK in ${ZT_CURRENT_NETWORKS}; do
+  if echo "$ZT_NETWORKS" | grep -q "$ZT_CURRENT_NETWORK"; then
+    echo "Keeping $ZT_CURRENT_NETWORK";  
+  else
+    echo "Leaving $ZT_CURRENT_NETWORK";
+    zerotier-cli leave $ZT_CURRENT_NETWORK;
+  fi
+done
 
 PHY_IFACE="$(ip route | grep default | cut -d' ' -f5)"
 
 # cut -f9 returns IP block (or - if no IP address), -f8 will return the network interface
-ZT_IFACE="$(zerotier-cli listnetworks | tail -n1 | cut -d' ' -f8)"
+ZT_IFACES="$(zerotier-cli listnetworks -j | jq -r '.[] | (.portDeviceName)')"
 
 sysctl -w net.ipv4.ip_forward=1
 
 # looping for multiple physical interfaces
 for IFACE in ${PHY_IFACE//\s/ }; do
   iptables -t nat -A POSTROUTING -o $IFACE -j MASQUERADE
-  iptables -A FORWARD -i $ZT_IFACE -o $IFACE -j ACCEPT
-  iptables -A FORWARD -i $IFACE -o $ZT_IFACE -m state --state RELATED,ESTABLISHED -j ACCEPT
+  # looping for multiple ZeroTier interfaces
+  for ZT_IFACE in ${ZT_IFACES}; do 
+    iptables -A FORWARD -i $ZT_IFACE -o $IFACE -j ACCEPT
+    iptables -A FORWARD -i $IFACE -o $ZT_IFACE -m state --state RELATED,ESTABLISHED -j ACCEPT
+  done
 done
 
 while true; do


### PR DESCRIPTION
Hi,

Thanks for creating an excellent balena-zerotier solution. I needed to connect to several networks simultaneously, which is supported by the ZeroTier solution. Consequently, I have added support for this by comma-separating multiple IDs in the balena environment variables. Removing IDs from the environment variable will also trigger a leave action from the respective networks.